### PR TITLE
Switch to Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.7"
+  - "3.9"
 install:
   - pip install -r requirements.txt
   - pip install black codecov coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.9-slim
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 


### PR DESCRIPTION
PennyLane discontinued Python 3.7 and it depends on the `sphinx-action` GitHub action. Hence, any features >3.7 will break the action.

Warning: [`sphinx-action` seems to break with Python 3.10](https://github.com/ammaraskar/sphinx-action/issues/43): either the issue there has to be resolved or another solution is required to continue having `sphinx-action` work.